### PR TITLE
Allow setting AWS region in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ mailer:
 
 A default `from:` and `to:` address is also required.
 
+To set a specific region, add to the `email-amazon.yaml` configuration with your desired region:
+
+```yaml
+region: us-east-1
+```
+
 ## Credits
 
 Thanks to the [Syfmony team](https://symfony.com) for making this plugin possible.

--- a/email-amazon.php
+++ b/email-amazon.php
@@ -57,6 +57,9 @@ class EmailAmazonPlugin extends Plugin
                 $dsn .= urlencode($options['access_key'] ?? '') .":".urlencode($options['secret_key'] ?? '');
             }
             $dsn .= "@default";
+            if (isset($options['region'])) {
+                $dsn .= "?region={$options['region']}";
+            }
             $e['dsn'] = $dsn;
             $e->stopPropagation();
         }


### PR DESCRIPTION
Without passing a region value, this plugin will use a default region.
Because SES requires region-specific configuration, attempts to send emails with the incorrect region will fail.

This change allows easily setting a specific region to be passed into amazon-mailer DSN string instead of having to configure on the default or override with another fallback.